### PR TITLE
Make the api_key variable more specific

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -3,7 +3,7 @@
   sudo: true
   vars:
     sys_packages: ["vim", "git"]
-    api_key: redacted
+    dataloop_api_key: redacted
   roles:
     - init
     - dataloop-agent

--- a/ansible/roles/dataloop-agent/templates/dataloop-agent.tpl
+++ b/ansible/roles/dataloop-agent/templates/dataloop-agent.tpl
@@ -7,7 +7,7 @@
 # Default-Stop:      0 1 6
 # Description:       Dataloop Agent
 ### END INIT INFO
-API_KEY={{ api_key }}
+API_KEY={{ dataloop_api_key }}
 SERVER=https://www.dataloop.io
 SCRIPT="/usr/local/bin/dataloop-lin-agent --api-key $API_KEY --server $SERVER"
 RUNAS=root


### PR DESCRIPTION
The variable name "api_key" is a little bit too generic imho and could be the api
key for any service, not just dataloop.

This patch changes the varname to dataloop_api_key meaning that it
can be overridden at will without worrying about affecting other
roles that could contain this same variable name.
