### PR TITLE
Add the ability to specify agent name via dataloop_agent_name var

### DIFF
--- a/roles/dataloop-agent/templates/dataloop-agent.yaml.j2
+++ b/roles/dataloop-agent/templates/dataloop-agent.yaml.j2
@@ -20,4 +20,10 @@ tags: {{ dataloop_tags }}
 {% endif %}
 
 ## Set if you would like a custom name for this agent. Default is hostname
+{% if dataloop_agent_name is defined %}
+name: {{ dataloop_agent_name }}
+{% endif %}
+
+{% if dataloop_agent_name is not defined %}
 #name:
+{% endif %}


### PR DESCRIPTION
I found that hostnames are not always best choice for agent names and there's no ability to set them via Ansible so there it goes