### PR TITLE
add explicit sudo

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -3,10 +3,13 @@
 
 # Add an Apt signing key, will not download if present
 - name: Add dataloop gpg key
+  sudo: true
   apt_key: id=113E2B8D url='https://download.dataloop.io/pubkey.gpg' state=present
 
 - name: Add dataloop apt repository
+  sudo: true
   apt_repository: repo='deb https://download.dataloop.io/deb/ stable main' state=present
 
 - name: Install dataloop
+  sudo: true
   apt: name=dataloop-agent state=present


### PR DESCRIPTION
Without a global sudo, these tasks will not run. Ansible v2 will introduce block sudos per task, until then, the role should run straight after install rather than requiring a global sudo.