### PR TITLE
ensure that apt https transport is installed

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,5 +1,7 @@
 ---
 # Ubuntu specific dataloop stuff
+- name: install https apt transport
+  apt: name=apt-transport-https state=present
 
 # Add an Apt signing key, will not download if present
 - name: Add dataloop gpg key


### PR DESCRIPTION
not included by default on minimal ubuntu install